### PR TITLE
[chore] Hyperlinks update after repo rename to `twi-wimse`

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
 # License
 
 See the
-[guidelines for contributions](https://github.com/confidential-computing/twi/blob/main/CONTRIBUTING.md).
+[guidelines for contributions](https://github.com/confidential-computing/twi-wimse/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 
 This is the working area for the individual Internet-Draft, "Trusted Workload Identity Reference Architecture".
 
-* [Editor's Copy](https://confidential-computing.github.io/twi/#go.draft-twi-reference-architecture.html)
+* [Editor's Copy](https://confidential-computing.github.io/twi-wimse/#go.draft-twi-reference-architecture.html)
 * [Datatracker Page](https://datatracker.ietf.org/doc/draft-twi-reference-architecture)
 * [Individual Draft](https://datatracker.ietf.org/doc/html/draft-twi-reference-architecture)
-* [Compare Editor's Copy to Individual Draft](https://confidential-computing.github.io/twi/#go.draft-twi-reference-architecture.diff)
+* [Compare Editor's Copy to Individual Draft](https://confidential-computing.github.io/twi-wimse/#go.draft-twi-reference-architecture.diff)
 
 
 ## Contributing
 
 See the
-[guidelines for contributions](https://github.com/confidential-computing/twi/blob/main/CONTRIBUTING.md).
+[guidelines for contributions](https://github.com/confidential-computing/twi-wimse/blob/main/CONTRIBUTING.md).
 
 Contributions can be made by creating pull requests.
 The GitHub interface supports creating pull requests using the Edit (✏) button.


### PR DESCRIPTION
Housekeeping: Updates to README and LICENSE files to reflect the new GH repository name (`twi`->`twi-wimse`)