### PR TITLE
Added a devcontainer for quick local preview of HTML I-D

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+# Based on https://github.com/devcontainers/templates/tree/main/src/ruby, with further customizations for IETF I-D
+FROM mcr.microsoft.com/devcontainers/ruby:1-3.3-bullseye
+RUN apt-get update \
+    && apt-get install -y python3.9 python3-pip python3-venv
+RUN pip3 install --upgrade xml2rfc iddiff svgcheck intervaltree pip wheel setuptools #just to get everything updated container-build-time
+RUN mkdir -p ~/.bundle/cache && chmod +t -R ~/.bundle/cache && gem install kdwatch

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,72 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+	"name": "IETF I-D Toolchain",
+	// More info: https://containers.dev/guide/dockerfile
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"http_proxy": "${localEnv:http_proxy}",
+			"https_proxy": "${localEnv:https_proxy}",
+			"no_proxy": "${localEnv:no_proxy}"
+		}
+	},
+	
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {	
+		"ghcr.io/hspaans/devcontainer-features/pymarkdownlnt:1": {
+			"version": "latest"
+		}
+		// ,
+		// "ghcr.io/devcontainers-extra/features/markdownlint-cli2:1": {
+		// 	"version": "latest"
+		// }
+	},
+	
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [3000],
+	"portsAttributes": {
+		"3000": {
+			"label": "KDWatch",
+			"description": "Auto-updated HTML version of the documentation",
+			"onAutoForward": "openBrowserOnce"
+		}
+	},
+	
+	"containerEnv": {
+		"HTTP_PROXY": "${localEnv:HTTP_PROXY}",
+		"HTTPS_PROXY": "${localEnv:HTTP_PROXY}",
+		"http_proxy": "${localEnv:HTTP_PROXY}",
+		"https_proxy": "${localEnv:HTTP_PROXY}",
+		"no_proxy": "${localEnv:NO_PROXY}",
+		"NO_PROXY": "${localEnv:NO_PROXY}"
+	},
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "rm -rf ./lib; make", // remove previously downloaded libraries on devcontainer change (to force toolchain update) & I-D toolchain
+
+	"postStartCommand": "kdwatch -p 3000",
+	
+	// Configure tool-specific properties.
+	"customizations": {
+		"codespaces": {
+			"openFiles": [
+				"draft-twi-reference-architecture.md"
+			]
+		},
+		"vscode": {
+			"extensions": [
+				"davidanson.vscode-markdownlint",
+				"bierner.markdown-mermaid",
+				"mermaidchart.vscode-mermaid-chart",
+				"github.copilot",
+				"shd101wyy.markdown-preview-enhanced",
+				"shd101wyy.markdown-preview-enhanced-plus",
+				"francescoboffa.rfc-reader",
+				"ms-vscode.live-server"
+			],
+			"settings": {}
+		}
+	}
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
## Adds support of [Dev Containers](https://containers.dev/) for easier local authoring. 
#### Purely OPTIONAL❕

When opened up in a compatible IDE _(i.e. VSCode, w/ [`Dev Containers` extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers))_ or [GH Codespace](https://github.com/codespaces/new?repo=confidential-computing/twi-wimse&ref=main), will open up a dev container pre-set up with the Internet Draft toolchain.
Note 1st launch may take a considerable while!

## Features supported
* All of the [goodness](https://github.com/martinthomson/i-d-template/blob/main/doc/FEATURES.md) brought by [martinthomson's I-D-Template](https://github.com/martinthomson/i-d-template) should 🤞  be available via `make` CLI commands
* By default, a [`kdwatch`](https://github.com/cabo/kdwatch)-based live renderer launches on startup and displays live preview of the document at [`http://localhost:3000`](http://127.0.0.1:3000/). 
    * Further information [here](https://authors.ietf.org/drafting-in-markdown)