### PR TITLE
[chore] Minor tweaks to the DevContainer for easier authoring

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,4 +3,13 @@ FROM mcr.microsoft.com/devcontainers/ruby:1-3.3-bullseye
 RUN apt-get update \
     && apt-get install -y python3.9 python3-pip python3-venv
 RUN pip3 install --upgrade xml2rfc iddiff svgcheck intervaltree pip wheel setuptools #just to get everything updated container-build-time
-RUN mkdir -p ~/.bundle/cache && chmod +t -R ~/.bundle/cache && gem install kdwatch
+RUN mkdir -p ~/.bundle/cache && chmod +t -R ~/.bundle/cache && gem install kdwatch kramdown-mermaid
+
+#Install mermaid-ascii
+# # Latest 
+# RUN curl -s https://api.github.com/repos/AlexanderGrooff/mermaid-ascii/releases/latest \
+#     | grep "browser_download_url.*mermaid-ascii" | grep "$(uname)_$(uname -m)" | cut -d: -f2,3 | tr -d \" \
+#     | wget -q -i- -O- | tar -xvz -f- -C /usr/bin -- mermaid-ascii
+#0.6.0
+RUN wget -q -O- https://github.com/AlexanderGrooff/mermaid-ascii/releases/download/0.6.0/mermaid-ascii_Linux_x86_64.tar.gz \
+    | tar -xvz -f- -C /usr/bin -- mermaid-ascii

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -44,7 +44,8 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "rm -rf ./lib; make", // remove previously downloaded libraries on devcontainer change (to force toolchain update) & I-D toolchain
 
-	"postStartCommand": "kdwatch -p 3000",
+	"postStartCommand": "nohup bash -c 'kdwatch -p 3000 &' >./kdwatch.out~ 2>&1", // start kdwatch in the background
+	"postAttachCommand": "echo -e '\\n\\n=========\\n= \\e[34mNOTICE\\e[37m: - kdwatch with I-D preview started on port 3000, open http://localhost:3000 in your browser (or navigate Ports tab in VSCode)\\n=         - mermaid-ascii is available in the shell for quick conversion between mermaid and ASCII diagrams\\e[0m\\n=========\\n'",
 	
 	// Configure tool-specific properties.
 	"customizations": {


### PR DESCRIPTION
Fixes container startup (`kdwatch` now launched in background) and adds `mermaid-ascii` CLI for easier conversion between Mermaid and ASCII diagrams